### PR TITLE
Fix StartProcess arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -12,7 +13,6 @@ import (
 var VersionString string
 
 func init() {
-	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
 }
 
@@ -33,6 +33,11 @@ func action(c *cli.Context) error {
 
 	if c.GlobalBool("debug") {
 		log.SetLevel(log.DebugLevel)
+	}
+	if c.GlobalBool("silent") {
+		log.SetOutput(ioutil.Discard)
+	} else {
+		log.SetOutput(os.Stdout)
 	}
 
 	code, err := validateArgs(c)
@@ -103,6 +108,11 @@ func cliFlags() []cli.Flag {
 			Name:   "debug",
 			Usage:  "Log additional debugging information",
 			EnvVar: "PARAMS_DEBUG",
+		},
+		cli.BoolFlag{
+			Name:   "silent",
+			Usage:  "Silence all logs",
+			EnvVar: "PARAMS_SILENT",
 		},
 	}
 }

--- a/runner.go
+++ b/runner.go
@@ -18,6 +18,10 @@ func RunCommand(command string, args []string, envVars []string) error {
 	procAttr.Env = envVars
 	procAttr.Files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
 
+	// prefix args with the command, as per https://golang.org/pkg/os/#StartProcess
+	// The argv slice will become os.Args in the new process, so it normally starts
+	// with the program name.
+	args = append([]string{command}, args...)
 	proc, err := os.StartProcess(command, args, procAttr)
 	if err != nil {
 		return err


### PR DESCRIPTION
As per https://golang.org/pkg/os/#StartProcess the argv slice will
become os.Args in the new process, so it normally starts with the
program name.

Defining 3 parameters in SSM under the `/prod/thing/main` path.
- `enabled`
- `connect`
- `saycurity`

Without the fix, `printenv` doesn't care about saysecurity positioned at argv[0] (where the command should be), so it prints all environment variables:
```
env-aws-params --aws-region us-east-1 --prefix /prod/thing/main --pristine /usr/bin/printenv saycurity 
INFO[0000] PID 16710 running /usr/bin/printenv saycurity 
enabled=true
saycurity=abc1234*
connect=10.100.0.1:2181,10.100.1.1:2181
```

With the fix, printenv only prints the value of the `saycurity` parameter, as expected.
```
env-aws-params --aws-region us-east-1 --prefix /prod/thing/main --pristine /usr/bin/printenv saycurity 
INFO[0000] PID 16696 running /usr/bin/printenv saycurity 
abc1234*
```

This PR also includes a commit to add a `--silent` option to the cli to prevent logs from being part of the output generated by the tool. The use case is for using `env-aws-params` to simply output all gathered variables to a file which can then be used in systemd units (`EnvironmentFile`).