### PR TITLE
Exit with failure when child does

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,10 @@ func main() {
 	app.Action = func(c *cli.Context) error {
 		return action(c)
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func action(c *cli.Context) error {
@@ -66,6 +69,9 @@ func action(c *cli.Context) error {
 
 	err = RunCommand(c.Args()[0], c.Args()[1:], envVars)
 	if err != nil {
+		if cmdError, ok := err.(*CommandFailedError); ok {
+			return cli.NewExitError(errorPrefix(err), cmdError.ExitCode)
+		}
 		return cli.NewExitError(errorPrefix(err), 128)
 	}
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func action(c *cli.Context) error {
 
 	params, err := getParameters(c)
 	if err != nil {
-		return cli.NewExitError(errorPrefix(err), code)
+		return cli.NewExitError(errorPrefix(err), -1)
 	}
 
 	envVars := BuildEnvVars(


### PR DESCRIPTION
This PR captures the exit code of the child process and returns it.  Previously the utility was exiting with a successful status code when the child process failed.  I also added a non-zero status code when reading parameters from the SSM fails.